### PR TITLE
Add FidFile.

### DIFF
--- a/clnt_open.go
+++ b/clnt_open.go
@@ -95,3 +95,9 @@ func (clnt *Clnt) FOpen(path string, mode uint8) (*File, error) {
 
 	return &File{fid, 0}, nil
 }
+
+// FidFile returns a File that represents the given Fid, initially at the given
+// offset.
+func FidFile(fid *Fid, offset uint64) *File {
+	return &File{fid, offset}
+}


### PR DESCRIPTION
Some go9p client users may work with Fids, but want the ability to
obtain a File given a raw Fid and offset (e.g. to pass to io package
functions).

Signed-off-by: Jamie Liu jamieliu@google.com
