### PR TITLE
explicitly cast qid.Path 

### DIFF
--- a/ufs.go
+++ b/ufs.go
@@ -100,7 +100,7 @@ func omode2uflags(mode uint8) int {
 func dir2Qid(d os.FileInfo) *Qid {
 	var qid Qid
 
-	qid.Path = d.Sys().(*syscall.Stat_t).Ino
+	qid.Path = uint64(d.Sys().(*syscall.Stat_t).Ino)
 	qid.Version = uint32(d.ModTime().UnixNano() / 1000000)
 	qid.Type = dir2QidType(d)
 


### PR DESCRIPTION
Because on some systems (e.g. FreeBSD apparently) Ino is uint32
and so the build fails.
