### PR TITLE
When attaching, set numeric username to NOUID if not using dotu.

### DIFF
--- a/go9p_test.go
+++ b/go9p_test.go
@@ -41,7 +41,7 @@ func TestAttachOpenReaddir(t *testing.T) {
 	var err error
 	flag.Parse()
 	ufs := new(Ufs)
-	ufs.Dotu = false
+	ufs.Dotu = true
 	ufs.Id = "ufs"
 	ufs.Root = *root
 	ufs.Debuglevel = *debug
@@ -194,7 +194,7 @@ var b = make([]byte, 1048576/8)
 // Not sure we want this, and the test has issues. Revive it if we ever find a use for it.
 func TestPipefs(t *testing.T) {
 	pipefs := new(Pipefs)
-	pipefs.Dotu = false
+	pipefs.Dotu = true
 	pipefs.Msize = 1048576
 	pipefs.Id = "pipefs"
 	pipefs.Root = *root

--- a/unpack.go
+++ b/unpack.go
@@ -112,6 +112,8 @@ func Unpack(buf []byte, dotu bool) (fc *Fcall, err error, fcsz int) {
 			} else {
 				fc.Unamenum = NOUID
 			}
+		} else {
+			fc.Unamenum = NOUID
 		}
 
 	case Rerror:


### PR DESCRIPTION
Missing else clause.  See:
https://github.com/9fans/plan9port/blob/master/src/lib9/convM2S.c#L106-L122

Fixes issue #8.

Functionally, this is very similar to the fix @mischief pushed in: 
https://github.com/lionkov/go9p/commit/11a63487351273ae0c2e0be51ef6331cda11dc81
