### PR TITLE
Update README.md for github's rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 This is go9p done in a way that I can understand.
 
 To install:
-  export GOPATH=~rminnich/go
-  go get -a github.com/rminnich/go9p
-  go get -a github.com/rminnich/go9p/ufs
-  go install -a github.com/rminnich/go9p/ufs
+    export GOPATH=~rminnich/go
+    go get -a github.com/rminnich/go9p
+    go get -a github.com/rminnich/go9p/ufs
+    go install -a github.com/rminnich/go9p/ufs
 
 ~/go/bin/ufs
 


### PR DESCRIPTION
The install instructions were wrapping into one run-on sentence.
Github wants four spaces to render a line as verbatim.
