### PR TITLE
cast Ino to uint64 in case you are on a 386 system

### DIFF
--- a/clnt_open.go
+++ b/clnt_open.go
@@ -6,6 +6,7 @@ package go9p
 
 import (
 	"strings"
+    "log"
 )
 
 // Opens the file associated with the fid. Returns nil if
@@ -82,8 +83,10 @@ func (clnt *Clnt) FCreate(path string, perm uint32, mode uint8) (*File, error) {
 
 // Opens a named file. Returns the opened file, or an Error.
 func (clnt *Clnt) FOpen(path string, mode uint8) (*File, error) {
+    log.Println("FOpen", path)
 	fid, err := clnt.FWalk(path)
 	if err != nil {
+        log.Println("failed after walk trying to walk path", path)
 		return nil, err
 	}
 

--- a/examples/ls/ls.go
+++ b/examples/ls/ls.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"github.com/hagna/go9p"
+	"io"
+	"log"
+	"os"
+)
+
+var debuglevel = flag.Int("d", 0, "debuglevel")
+var addr = flag.String("addr", "127.0.0.1:5640", "network address")
+
+func main() {
+	var user go9p.User
+	var err error
+	var c *go9p.Clnt
+	var file *go9p.File
+	var d []*go9p.Dir
+
+	flag.Parse()
+	user = go9p.OsUsers.Uid2User(os.Geteuid())
+	go9p.DefaultDebuglevel = *debuglevel
+	c, err = go9p.Mount("tcp", *addr, "", 8192, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	lsarg := "/"
+	if flag.NArg() == 1 {
+		lsarg = flag.Arg(0)
+	} else if flag.NArg() > 1 {
+		log.Fatal("error: only one argument expected")
+	}
+
+	file, err = c.FOpen(lsarg, go9p.OREAD)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		d, err = file.Readdir(0)
+		if d == nil || len(d) == 0 || err != nil {
+			break
+		}
+
+		for i := 0; i < len(d); i++ {
+			os.Stdout.WriteString(d[i].Name + "\n")
+		}
+	}
+
+	file.Close()
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+
+	return
+}

--- a/examples/read/read.go
+++ b/examples/read/read.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/hagna/go9p"
+	"flag"
+	"io"
+	"log"
+	"os"
+)
+
+var debuglevel = flag.Int("d", 0, "debuglevel")
+var addr = flag.String("addr", "127.0.0.1:5640", "network address")
+
+func main() {
+	var n int
+	var user go9p.User
+	var err error
+	var c *go9p.Clnt
+	var file *go9p.File
+	var buf []byte
+
+	flag.Parse()
+	user = go9p.OsUsers.Uid2User(os.Geteuid())
+	go9p.DefaultDebuglevel = *debuglevel
+	c, err = go9p.Mount("tcp", *addr, "/", 8192, user)
+	if err != nil {
+		goto error
+	}
+
+	if flag.NArg() != 1 {
+		log.Println("invalid arguments")
+		return
+	}
+
+	file, err = c.FOpen(flag.Arg(0), go9p.OREAD)
+	if err != nil {
+		goto error
+	}
+
+	buf = make([]byte, 8192)
+	for {
+		n, err = file.Read(buf)
+		if n == 0 {
+			break
+		}
+
+		os.Stdout.Write(buf[0:n])
+	}
+
+	file.Close()
+
+	if err != nil && err != io.EOF {
+		goto error
+	}
+
+	return
+
+error:
+	log.Println("Error", err)
+}

--- a/examples/slave/main.go
+++ b/examples/slave/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/hagna/go9p"
+	"log"
+	"time"
+	"os"
+)
+
+var addr = flag.String("addr", ":5640", "network address")
+var debug = flag.Int("debug", 0, "print debug messages")
+var root = flag.String("root", "/", "root filesystem")
+
+type Time struct {
+	go9p.SrvFile
+}
+
+func (*Time) Read(fid *go9p.FFid, buf []byte, offset uint64) (int, error) {
+	b := []byte(time.Now().String())
+	have := len(b)
+	off := int(offset)
+
+	if off >= have {
+		return 0, nil
+	}
+
+	return copy(buf, b[off:]), nil
+}
+
+func (*Time) Write(fid *go9p.FFid, data []byte, offset uint64) (int, error)  {
+	log.Println("fid is", fid)
+	log.Println("buf is", string(data))
+
+	log.Println("offset is", offset)
+	return len(data), nil
+}
+
+func (*Time) Open(fid *go9p.FFid, mode uint8) error {
+	log.Println("Open", fid)
+	return nil
+}
+
+
+func main() {
+	flag.Parse()
+	pfs := new(go9p.Procfs)
+	ufs := new(go9p.Ufs)
+	pfs.Ufs = ufs 
+	ufs.Dotu = true
+	ufs.Id = "ufs"
+	ufs.Root = *root
+	ufs.Debuglevel = *debug
+//	ufs.statsRegister()
+	ufs.Start(pfs)
+
+	user := go9p.OsUsers.Uid2User(os.Geteuid())
+	root := new(go9p.SrvFile)
+	err := root.Add(nil, "/", user, nil, go9p.DMDIR|0555, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tm := new(Time)
+	err = tm.Add(root, "time", go9p.OsUsers.Uid2User(os.Geteuid()), nil, 0777, tm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tm2 := new(Time)
+	err = tm2.Add(root, "d", go9p.OsUsers.Uid2User(os.Geteuid()), nil, 0444&go9p.DMDIR, tm2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fs := go9p.NewsrvFileSrv(root)
+	fs.Dotu = true
+	pfs.Fsrv = fs
+	fs.Start(pfs)
+
+	fmt.Print("procfs starting\n")
+	// determined by build tags
+	//extraFuncs()
+	err = ufs.StartNetListener("tcp", *addr)
+	if err != nil {
+		log.Println(err)
+	}
+}

--- a/examples/write/write.go
+++ b/examples/write/write.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"flag"
+	"github.com/hagna/go9p"
+	"io"
+	"log"
+	"os"
+)
+
+var debuglevel = flag.Int("d", 0, "debuglevel")
+var addr = flag.String("addr", "127.0.0.1:5640", "network address")
+
+func main() {
+	var n, m int
+	var user go9p.User
+	var err error
+	var c *go9p.Clnt
+	var file *go9p.File
+	var buf []byte
+
+	flag.Parse()
+	user = go9p.OsUsers.Uid2User(os.Geteuid())
+	go9p.DefaultDebuglevel = *debuglevel
+	c, err = go9p.Mount("tcp", *addr, "", 8192, user)
+	if err != nil {
+		goto error
+	}
+
+	if flag.NArg() != 1 {
+		log.Println("invalid arguments")
+		return
+	}
+
+	file, err = c.FOpen(flag.Arg(0), go9p.OWRITE|go9p.OTRUNC)
+	if err != nil {
+		file, err = c.FCreate(flag.Arg(0), 0666, go9p.OWRITE)
+		if err != nil {
+			goto error
+		}
+	}
+
+	buf = make([]byte, 8192)
+	for {
+		n, err = os.Stdin.Read(buf)
+		if err != nil && err != io.EOF {
+			goto error
+		}
+
+		if n == 0 {
+			break
+		}
+
+		m, err = file.Write(buf[0:n])
+		if err != nil {
+			goto error
+		}
+
+		if m != n {
+			err = &go9p.Error{"short write", 0}
+			goto error
+		}
+	}
+
+	file.Close()
+	return
+
+error:
+	log.Println("Error", err)
+}

--- a/p9.go
+++ b/p9.go
@@ -42,6 +42,7 @@ const (
 	Rstat
 	Twstat
 	Rwstat
+	Theartbeat
 	Tlast
 )
 

--- a/procfs.go
+++ b/procfs.go
@@ -1,0 +1,295 @@
+package go9p
+
+import (
+	"log"
+	"os"
+	pathpkg "path"
+	"strings"
+)
+
+type Procfs struct {
+	*Ufs
+	*Fsrv
+}
+
+func (pfs *Procfs) Attach(req *SrvReq) {
+	switch req.Tc.Aname {
+	case "/d":
+		pfs.Ufs.Attach(req)
+	case "", "/":
+		pfs.Fsrv.Attach(req)
+	}
+}
+
+type stfn func(*wctx) stfn
+
+type wctx struct {
+	req *SrvReq
+	fid interface{}
+	nfid interface{}
+	qids []Qid
+	path string
+	count int
+	fp *SrvFile
+	mnt string
+	ufsRoot string
+	fsRoot *SrvFile
+}
+
+func walker(req *SrvReq, ctx *wctx) {
+	st := st_init(ctx)
+	for st != nil {
+		st = st(ctx)
+	}
+}
+
+func st_init(ctx *wctx) stfn {
+	ctx.qids = make([]Qid, len(ctx.req.Tc.Wname))
+	switch ctx.req.Fid.Aux.(type) {
+	case *ufsFid:
+		req := ctx.req
+		tc := req.Tc
+		fid := req.Fid.Aux.(*ufsFid)
+		ctx.fid = fid
+		
+		err := fid.stat()
+		if err != nil {
+			log.Printf("failed to stat fid %+v error %+v", fid, err)
+			req.RespondError(err)
+			return nil
+		}
+		ctx.path = fid.path
+		if req.Newfid.Aux == nil {
+			req.Newfid.Aux = new(ufsFid)
+		}
+
+		ctx.nfid = req.Newfid.Aux.(*ufsFid)
+		ctx.count = len(tc.Wname)
+		return st_ufswalk
+
+	case *FFid:
+		req := ctx.req
+		fid := req.Fid.Aux.(*FFid)
+		if req.Newfid.Aux == nil {
+			nfid := new(FFid)
+			nfid.Fid = req.Newfid
+			req.Newfid.Aux = nfid
+		}
+
+		ctx.nfid = req.Newfid.Aux.(*FFid)
+		ctx.count = len(req.Tc.Wname)
+		ctx.fp = fid.F
+		return st_fswalk
+	}
+	return nil
+}
+
+func st_ufswalk(ctx *wctx) stfn {
+	path := ctx.path
+	req := ctx.req
+	tc := req.Tc
+	i := len(tc.Wname) - ctx.count
+	if len(tc.Wname) == 0 {
+		return st_ufswalk_done
+	}
+	p := path + "/" + tc.Wname[i]
+	if "/" + tc.Wname[i] == ctx.mnt && i == 0  {
+		log.Println("found the mountpoint prefix on item 0 so I'm removing it")
+		p = ctx.ufsRoot
+	}
+	if tc.Wname[i] == ".." {
+		chk := pathpkg.Join("realroot", p)
+		if chk == "realroot" {
+			fid := new(FFid)
+			fid.F = ctx.fsRoot
+			req.Fid.Aux = fid
+			ctx.nfid = new(FFid)
+			req.Newfid.Aux = ctx.nfid
+			return st_fswalk
+		}
+	}
+	st, err := os.Lstat(p)
+	if err != nil {
+		if i == 0 {
+			log.Println("Enoent", err)
+			req.RespondError(Enoent)
+			return nil
+		}
+		log.Printf("this is the error about failed os.Lstat on %+v: %v", p, err)
+		return st_ufswalk_done
+	}
+	ctx.qids[i] = *dir2Qid(st)
+	ctx.path = p
+	ctx.count -= 1
+	if ctx.count == 0 {
+		return st_ufswalk_done
+	}
+	return st_ufswalk
+}
+
+func st_ufswalk_done(ctx *wctx) stfn {
+	req := ctx.req
+	tc := req.Tc
+	if ctx.count != 0 {
+		log.Println("oops did not read all of Wname", tc.Wname)
+	}
+	ctx.nfid.(*ufsFid).path = ctx.path
+	ctx.req.RespondRwalk(ctx.qids[0:len(tc.Wname) - ctx.count])
+	return nil
+}
+
+
+func st_fswalk(ctx *wctx) stfn {
+	req := ctx.req
+	tc := req.Tc
+	i :=  len(tc.Wname) - ctx.count
+	f := ctx.fp
+	wqids := ctx.qids
+	if len(tc.Wname) == 0 {
+		return st_fswalk_done
+	}
+	if tc.Wname[i] == ".." {
+		// handle dotdot
+		f = f.Parent
+		wqids[i] = f.Qid
+		ctx.count -= 1
+		if ctx.count == 0 {
+			return st_fswalk_done
+		}
+		return st_fswalk
+	}
+	if "/" + tc.Wname[i] == ctx.mnt {
+		req.Fid.Aux = new(ufsFid)
+		req.Fid.Aux.(*ufsFid).path = "/"
+		ctx.nfid = new(ufsFid)
+		req.Newfid.Aux = ctx.nfid 
+		return st_ufswalk
+	}
+	if (wqids[i].Type & QTDIR) > 0 {
+		if !f.CheckPerm(req.Fid.User, DMEXEC) {
+			return st_fswalk_done
+		}
+	}
+
+	p := f.Find(tc.Wname[i])
+	if p == nil {
+		return st_fswalk_done
+	}
+	f = p
+	ctx.fp = f
+	wqids[i] = f.Qid
+	ctx.count -= 1
+	if ctx.count == 0 {
+		return st_fswalk_done
+	}
+	return st_fswalk
+}
+
+func st_fswalk_done(ctx *wctx) stfn {
+	req := ctx.req
+	tc := req.Tc
+	if len(tc.Wname) > 0 && ctx.count != 0 {
+		req.RespondError(Enoent)
+		return nil
+	}
+	ctx.nfid.(*FFid).F = ctx.fp
+	req.RespondRwalk(ctx.qids[0:len(tc.Wname) - ctx.count])
+	return nil
+}
+
+
+// hasPathPrefix returns true if x == y or x == y + "/" + more
+func hasPathPrefix(x, y string) bool {
+	return x == y || strings.HasPrefix(x, y) && (strings.HasSuffix(y, "/") || strings.HasPrefix(x[len(y):], "/"))
+}
+
+func translate(old, new, path string) string {
+	path = pathpkg.Clean("/" + path)
+	if !hasPathPrefix(path, old) {
+		log.Println("translate " + path + " but old=" + old)
+	}
+	return pathpkg.Join(new, path[len(old):])
+}
+
+
+func (pfs *Procfs) Walk(req *SrvReq) {
+	ctx := new(wctx)
+	ctx.req = req
+	ctx.ufsRoot = pfs.Ufs.Root
+	ctx.fsRoot = pfs.Fsrv.Root
+	ctx.mnt = "/d"
+	walker(req, ctx)
+
+}
+
+func (pfs *Procfs) Open(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Open(req)
+	case *FFid:
+		pfs.Fsrv.Open(req)
+	}
+}
+
+func (pfs *Procfs) Create(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Create(req)
+	case *FFid:
+		pfs.Fsrv.Create(req)
+	}
+}
+
+func (pfs *Procfs) Read(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Read(req)
+	case *FFid:
+		pfs.Fsrv.Read(req)
+	}
+}
+
+func (pfs *Procfs) Write(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Write(req)
+	case *FFid:
+		pfs.Fsrv.Write(req)
+	}
+}
+
+func (pfs *Procfs) Clunk(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Clunk(req)
+	case *FFid:
+		pfs.Fsrv.Clunk(req)
+	}
+}
+
+func (pfs *Procfs) Remove(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Remove(req)
+	case *FFid:
+		pfs.Fsrv.Remove(req)
+	}
+}
+
+func (pfs *Procfs) Stat(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Stat(req)
+	case *FFid:
+		pfs.Fsrv.Stat(req)
+	}
+}
+
+func (pfs *Procfs) Wstat(req *SrvReq) {
+	switch req.Fid.Aux.(type) {
+	case *ufsFid:
+		pfs.Ufs.Wstat(req)
+	case *FFid:
+		pfs.Fsrv.Wstat(req)
+	}
+}

--- a/slave_test.go
+++ b/slave_test.go
@@ -1,0 +1,193 @@
+// Copyright 2009 The go9p Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package go9p
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"testing"
+)
+
+/*const numDir = 16384
+
+var addr = flag.String("addr", ":5640", "network address")
+var pipefsaddr = flag.String("pipefsaddr", ":5641", "pipefs network address")
+var debug = flag.Int("debug", 0, "print debug messages")
+var root = flag.String("root", "/", "root filesystem")
+
+// Two files, dotu was true.
+var testunpackbytes = []byte{
+	79, 0, 0, 0, 0, 0, 0, 0, 0, 228, 193, 233, 248, 44, 145, 3, 0, 0, 0, 0, 0, 164, 1, 0, 0, 0, 0, 0, 0, 47, 117, 180, 83, 102, 3, 0, 0, 0, 0, 0, 0, 6, 0, 112, 97, 115, 115, 119, 100, 4, 0, 110, 111, 110, 101, 4, 0, 110, 111, 110, 101, 4, 0, 110, 111, 110, 101, 0, 0, 232, 3, 0, 0, 232, 3, 0, 0, 255, 255, 255, 255, 78, 0, 0, 0, 0, 0, 0, 0, 0, 123, 171, 233, 248, 42, 145, 3, 0, 0, 0, 0, 0, 164, 1, 0, 0, 0, 0, 0, 0, 41, 117, 180, 83, 195, 0, 0, 0, 0, 0, 0, 0, 5, 0, 104, 111, 115, 116, 115, 4, 0, 110, 111, 110, 101, 4, 0, 110, 111, 110, 101, 4, 0, 110, 111, 110, 101, 0, 0, 232, 3, 0, 0, 232, 3, 0, 0, 255, 255, 255, 255,
+}
+*/
+
+func TestUnpackDirSlave(t *testing.T) {
+	b := testunpackbytes
+	for len(b) > 0 {
+		var err error
+		if _, b, _, err = UnpackDir(b, true); err != nil {
+			t.Fatalf("Unpackdir: %v", err)
+		}
+	}
+}
+
+func TestSlaveAttachOpenReaddir(t *testing.T) {
+	var err error
+	flag.Parse()
+	ufs := new(Slavefs)
+	ufs.Dotu = false
+	ufs.Id = "ufs"
+	ufs.Root = *root
+	ufs.Debuglevel = *debug
+	ufs.Start(ufs)
+
+	t.Log("ufs starting\n")
+	// determined by build tags
+	//extraFuncs()
+	go func() {
+		if err = ufs.StartNetListener("tcp", *addr); err != nil {
+			t.Fatalf("Can not start listener: %v", err)
+		}
+	}()
+	/* this may take a few tries ... */
+	var conn net.Conn
+	for i := 0; i < 160; i++ {
+		if conn, err = net.Dial("tcp", *addr); err != nil {
+			t.Logf("Try go connect, %d'th try, %v", i, err)
+		} else {
+			t.Logf("Got a conn, %v\n", conn)
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("Connect failed after many tries ...")
+	}
+
+	root := OsUsers.Uid2User(0)
+
+    var dir string
+	dirparent, err := ioutil.TempDir("", "slavefs")
+    dir, err = ioutil.TempDir(dirparent, "go9p")
+	if err != nil {
+		t.Fatalf("got %v, want nil", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Now create a whole bunch of files to test readdir
+	for i := 0; i < numDir; i++ {
+		f := fmt.Sprintf(path.Join(dir, fmt.Sprintf("%d", i)))
+		if err := ioutil.WriteFile(f, []byte(f), 0600); err != nil {
+			t.Fatalf("Create %v: got %v, want nil", f, err)
+		}
+	}
+
+	var clnt *Clnt
+	for i := 0; i < 16; i++ {
+		clnt, err = Mount("tcp", *addr, dir, 8192, root)
+	}
+	if err != nil {
+		t.Fatalf("Connect failed: %v\n", err)
+	}
+
+	defer clnt.Unmount()
+	t.Logf("attached, rootfid %v\n", clnt.Root)
+
+	dirfid := clnt.FidAlloc()
+	if _, err = clnt.Walk(clnt.Root, dirfid, []string{"."}); err != nil {
+		t.Fatalf("%v", err)
+	}
+	if err = clnt.Open(dirfid, 0); err != nil {
+		t.Fatalf("%v", err)
+	}
+	var b []byte
+	var i, amt int
+	var offset uint64
+	for i < numDir {
+		if b, err = clnt.Read(dirfid, offset, 64*1024); err != nil {
+			t.Fatalf("%v", err)
+		}
+		for b != nil && len(b) > 0 {
+			if _, b, amt, err = UnpackDir(b, ufs.Dotu); err != nil {
+				break
+			} else {
+				i++
+				offset += uint64(amt)
+			}
+		}
+	}
+	if i != numDir {
+		t.Fatalf("Reading %v: got %d entries, wanted %d", dir, i, numDir)
+	}
+
+	// Alternate form, using readdir and File
+	var dirfile *File
+	if dirfile, err = clnt.FOpen("/slavefs/.", OREAD); err != nil {
+		t.Fatalf("%v", err)
+	}
+	i, amt, offset = 0, 0, 0
+	for i < numDir {
+		if d, err := dirfile.Readdir(numDir); err != nil {
+			t.Fatalf("%v", err)
+		} else {
+			i += len(d)
+		}
+	}
+	if i != numDir {
+		t.Fatalf("Readdir %v: got %d entries, wanted %d", dir, i, numDir)
+	}
+
+	// now test partial reads.
+	// Read 128 bytes at a time. Remember the last successful offset.
+	// if UnpackDir fails, read again from that offset
+	t.Logf("NOW TRY PARTIAL")
+	i, amt, offset = 0, 0, 0
+	for {
+		var b []byte
+		var d *Dir
+		if b, err = clnt.Read(dirfid, offset, 128); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if len(b) == 0 {
+			break
+		}
+		t.Logf("b %v\n", b)
+		for b != nil && len(b) > 0 {
+			t.Logf("len(b) %v\n", len(b))
+			if d, b, amt, err = UnpackDir(b, ufs.Dotu); err != nil {
+				// this error is expected ...
+				t.Logf("unpack failed (it's ok!). retry at offset %v\n",
+					offset)
+				break
+			} else {
+				t.Logf("d %v\n", d)
+				offset += uint64(amt)
+			}
+		}
+	}
+
+	t.Logf("NOW TRY WAY TOO SMALL")
+	i, amt, offset = 0, 0, 0
+	for {
+		var b []byte
+		if b, err = clnt.Read(dirfid, offset, 32); err != nil {
+			t.Logf("dirread fails as expected: %v\n", err)
+			break
+		}
+		if offset == 0 && len(b) == 0 {
+			t.Fatalf("too short dirread returns 0 (no error)")
+		}
+		if len(b) == 0 {
+			break
+		}
+		// todo: add entry accumulation and validation here..
+		offset += uint64(len(b))
+	}
+}
+
+

--- a/srv_conn.go
+++ b/srv_conn.go
@@ -7,6 +7,7 @@ package go9p
 import (
 	"fmt"
 	"log"
+    "github.com/davecgh/go-spew/spew"
 	"net"
 )
 
@@ -35,9 +36,12 @@ func (srv *Srv) NewConn(c net.Conn) {
 		op.ConnOpened(conn)
 	}
 
-	if sop, ok := (interface{}(conn)).(StatsOps); ok {
+
+	if sop, ok := (interface{}(conn)).(StatsOps); ok {   
 		sop.statsRegister()
+		log.Println("register stats!")
 	}
+	
 
 	go conn.recv()
 	go conn.send()
@@ -126,7 +130,8 @@ func (conn *Conn) recv() {
 			if conn.Debuglevel > 0 {
 				conn.logFcall(req.Tc)
 				if conn.Debuglevel&DbgPrintPackets != 0 {
-					log.Println(">->", conn.Id, fmt.Sprint(req.Tc.Pkt))
+					//log.Println(">->", conn.Id, fmt.Sprint(req.Tc.Pkt))
+					log.Println(">->", conn.Id, spew.Sdump(req.Tc.Pkt))
 				}
 
 				if conn.Debuglevel&DbgPrintFcalls != 0 {
@@ -183,7 +188,8 @@ func (conn *Conn) send() {
 			if conn.Debuglevel > 0 {
 				conn.logFcall(req.Rc)
 				if conn.Debuglevel&DbgPrintPackets != 0 {
-					log.Println("<-<", conn.Id, fmt.Sprint(req.Rc.Pkt))
+					//log.Println("<-<", conn.Id, fmt.Sprint(req.Rc.Pkt))
+					log.Println("<-<", conn.Id, spew.Sdump(req.Rc.Pkt))
 				}
 
 				if conn.Debuglevel&DbgPrintFcalls != 0 {

--- a/srv_stats_http.go
+++ b/srv_stats_http.go
@@ -27,6 +27,7 @@ func register(s string, h http.Handler) {
 	mux.Unlock()
 }
 func (srv *Srv) statsRegister() {
+
 	httponce.Do(func() {
 		http.HandleFunc("/go9p/", StatsHandler)
 		go http.ListenAndServe(":6060", nil)

--- a/ufs.go
+++ b/ufs.go
@@ -100,7 +100,7 @@ func omode2uflags(mode uint8) int {
 func dir2Qid(d os.FileInfo) *Qid {
 	var qid Qid
 
-	qid.Path = d.Sys().(*syscall.Stat_t).Ino
+	qid.Path = uint64(d.Sys().(*syscall.Stat_t).Ino)
 	qid.Version = uint32(d.ModTime().UnixNano() / 1000000)
 	qid.Type = dir2QidType(d)
 

--- a/ufs.go
+++ b/ufs.go
@@ -100,7 +100,7 @@ func omode2uflags(mode uint8) int {
 func dir2Qid(d os.FileInfo) *Qid {
 	var qid Qid
 
-	qid.Path = uint64(d.Sys().(*syscall.Stat_t).Ino)
+	qid.Path = d.Sys().(*syscall.Stat_t).Ino
 	qid.Version = uint32(d.ModTime().UnixNano() / 1000000)
 	qid.Type = dir2QidType(d)
 
@@ -294,9 +294,10 @@ func (ufs *Ufs) Attach(req *SrvReq) {
 func (*Ufs) Flush(req *SrvReq) {}
 
 func (*Ufs) Walk(req *SrvReq) {
+
 	fid := req.Fid.Aux.(*ufsFid)
 	tc := req.Tc
-
+	log.Printf("fid is %+v", fid)
 	err := fid.stat()
 	if err != nil {
 		req.RespondError(err)
@@ -546,6 +547,7 @@ func (*Ufs) Remove(req *SrvReq) {
 
 func (*Ufs) Stat(req *SrvReq) {
 	fid := req.Fid.Aux.(*ufsFid)
+	log.Println("Stat fid is", fid)
 	err := fid.stat()
 	if err != nil {
 		req.RespondError(err)


### PR DESCRIPTION
Without this I get the following error on freebsd_386:

github.com/rminnich/go9p/ufs.go:103: cannot use d.Sys().(*syscall.Stat_t).Ino (type uint32) as type uint64 in assignment
