### PR TITLE
ensure syscall.Stat_t is uint64 for FreeBSD compat

### DIFF
--- a/ufs.go
+++ b/ufs.go
@@ -100,7 +100,7 @@ func omode2uflags(mode uint8) int {
 func dir2Qid(d os.FileInfo) *Qid {
 	var qid Qid
 
-	qid.Path = d.Sys().(*syscall.Stat_t).Ino
+	qid.Path = uint64(d.Sys().(*syscall.Stat_t).Ino)
 	qid.Version = uint32(d.ModTime().UnixNano() / 1000000)
 	qid.Type = dir2QidType(d)
 


### PR DESCRIPTION
syscall.Stat_t is uint32 instead of uint64 on FreeBSD.
Tested on FreeBSD 11.0-RELEASE with go 1.7.1.