### PR TITLE
test: add comprehensive unit tests for client, server, and file operations

### DIFF
--- a/clnt_clnt_test.go
+++ b/clnt_clnt_test.go
@@ -1,0 +1,20 @@
+package go9p
+
+import "testing"
+
+func TestFidFile(t *testing.T) {
+	fid := &Fid{Fid: 1}
+	file := FidFile(fid, 42)
+	if file.Fid != fid {
+		t.Fatalf("FidFile fid mismatch")
+	}
+	if file.offset != 42 {
+		t.Fatalf("FidFile offset = %d", file.offset)
+	}
+}
+
+func TestClntLogFcall(t *testing.T) {
+	clnt := &Clnt{Debuglevel: DbgLogPackets | DbgLogFcalls, Log: NewLogger(8)}
+	fc := &Fcall{Type: Tversion, Pkt: []byte("pkt")}
+	clnt.logFcall(fc)
+}

--- a/clnt_tag_test.go
+++ b/clnt_tag_test.go
@@ -1,0 +1,325 @@
+package go9p
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+type stubUser struct {
+	name string
+	id   int
+}
+
+func (u stubUser) Name() string          { return u.name }
+func (u stubUser) Id() int               { return u.id }
+func (u stubUser) Groups() []Group       { return nil }
+func (u stubUser) IsMember(g Group) bool { return false }
+
+func newTestTag(t *testing.T) (*Clnt, *Tag, chan *Req) {
+	t.Helper()
+	clnt := &Clnt{
+		Msize:   256,
+		reqout:  make(chan *Req, 16),
+		tagpool: NewPool(0, uint32(NOTAG)),
+	}
+	reqchan := make(chan *Req, 16)
+	tag := clnt.TagAlloc(reqchan)
+	t.Cleanup(func() {
+		clnt.TagFree(tag)
+	})
+	return clnt, tag, reqchan
+}
+
+func waitReq(t *testing.T, ch <-chan *Req) *Req {
+	t.Helper()
+	select {
+	case req := <-ch:
+		return req
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for request")
+		return nil
+	}
+}
+
+func TestTagMethods(t *testing.T) {
+	clnt, tag, _ := newTestTag(t)
+	user := stubUser{name: "user", id: 1}
+
+	tests := []struct {
+		name     string
+		call     func(*Tag) (*Fid, *Fid, error)
+		wantType uint8
+		check    func(t *testing.T, fid *Fid, newfid *Fid, req *Req)
+	}{
+		{
+			name: "auth",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				afid := &Fid{Fid: 1, Clnt: clnt}
+				err := tag.Auth(afid, user, "srv")
+				return afid, nil, err
+			},
+			wantType: Tauth,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if fid.User == nil || fid.User.Name() != user.Name() {
+					t.Fatalf("Auth user = %#v", fid.User)
+				}
+			},
+		},
+		{
+			name: "attach",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 2, Clnt: clnt}
+				err := tag.Attach(fid, nil, user, "srv")
+				return fid, nil, err
+			},
+			wantType: Tattach,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if fid.User == nil || fid.User.Name() != user.Name() {
+					t.Fatalf("Attach user = %#v", fid.User)
+				}
+			},
+		},
+		{
+			name: "walk-no-names",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{
+					Fid:  3,
+					Clnt: clnt,
+					User: user,
+					Qid:  Qid{Type: QTDIR, Path: 1, Version: 2},
+				}
+				newfid := &Fid{Fid: 4, Clnt: clnt}
+				err := tag.Walk(fid, newfid, nil)
+				return fid, newfid, err
+			},
+			wantType: Twalk,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if newfid.Qid != fid.Qid {
+					t.Fatalf("Walk qid = %+v, want %+v", newfid.Qid, fid.Qid)
+				}
+				if newfid.User != fid.User {
+					t.Fatalf("Walk user = %#v", newfid.User)
+				}
+			},
+		},
+		{
+			name: "open",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 5, Clnt: clnt}
+				err := tag.Open(fid, OWRITE)
+				return fid, nil, err
+			},
+			wantType: Topen,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if fid.Mode != OWRITE {
+					t.Fatalf("Open mode = %d", fid.Mode)
+				}
+			},
+		},
+		{
+			name: "create",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 6, Clnt: clnt}
+				err := tag.Create(fid, "file", 0644, OREAD, "")
+				return fid, nil, err
+			},
+			wantType: Tcreate,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if fid.Mode != OREAD {
+					t.Fatalf("Create mode = %d", fid.Mode)
+				}
+			},
+		},
+		{
+			name: "read",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 7, Clnt: clnt}
+				err := tag.Read(fid, 0, 16)
+				return fid, nil, err
+			},
+			wantType: Tread,
+		},
+		{
+			name: "write",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 8, Clnt: clnt}
+				err := tag.Write(fid, []byte("data"), 0)
+				return fid, nil, err
+			},
+			wantType: Twrite,
+			check: func(t *testing.T, fid *Fid, newfid *Fid, req *Req) {
+				if req.Tc.Count != 4 {
+					t.Fatalf("Write count = %d", req.Tc.Count)
+				}
+			},
+		},
+		{
+			name: "clunk",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 9, Clnt: clnt}
+				err := tag.Clunk(fid)
+				return fid, nil, err
+			},
+			wantType: Tclunk,
+		},
+		{
+			name: "remove",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 10, Clnt: clnt}
+				err := tag.Remove(fid)
+				return fid, nil, err
+			},
+			wantType: Tremove,
+		},
+		{
+			name: "stat",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 11, Clnt: clnt}
+				err := tag.Stat(fid)
+				return fid, nil, err
+			},
+			wantType: Tstat,
+		},
+		{
+			name: "wstat",
+			call: func(tag *Tag) (*Fid, *Fid, error) {
+				fid := &Fid{Fid: 12, Clnt: clnt}
+				dir := &Dir{Name: "file"}
+				err := tag.Wstat(fid, dir)
+				return fid, nil, err
+			},
+			wantType: Twstat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fid, newfid, err := tt.call(tag)
+			if err != nil {
+				t.Fatalf("%s error = %v", tt.name, err)
+			}
+			req := waitReq(t, clnt.reqout)
+			if req.Tc.Type != tt.wantType {
+				t.Fatalf("%s type = %d, want %d", tt.name,
+					req.Tc.Type, tt.wantType)
+			}
+			if tt.check != nil {
+				tt.check(t, fid, newfid, req)
+			}
+			tag.ReqFree(req)
+		})
+	}
+}
+
+func TestTagReqprocUpdates(t *testing.T) {
+	clnt, tag, reqchan := newTestTag(t)
+	user := stubUser{name: "user", id: 1}
+
+	tests := []struct {
+		name        string
+		tcType      uint8
+		rc          *Fcall
+		startUser   User
+		startMode   uint8
+		wantQid     Qid
+		wantIounit  uint32
+		wantUserNil bool
+		wantMode    uint8
+		wantWalked  bool
+	}{
+		{
+			name:      "attach-success",
+			tcType:    Tattach,
+			rc:        &Fcall{Type: Rattach, Qid: Qid{Type: QTDIR, Path: 1}},
+			startUser: user,
+			wantQid:   Qid{Type: QTDIR, Path: 1},
+		},
+		{
+			name:        "walk-error",
+			tcType:      Twalk,
+			rc:          &Fcall{Type: Rerror, Error: "missing"},
+			startUser:   user,
+			wantUserNil: true,
+		},
+		{
+			name:       "create-success",
+			tcType:     Tcreate,
+			rc:         &Fcall{Type: Rcreate, Qid: Qid{Type: QTFILE, Path: 2}, Iounit: 99},
+			startUser:  user,
+			startMode:  OWRITE,
+			wantQid:    Qid{Type: QTFILE, Path: 2},
+			wantMode:   OWRITE,
+			wantIounit: 99,
+		},
+		{
+			name:        "create-error",
+			tcType:      Tcreate,
+			rc:          &Fcall{Type: Rerror, Error: "fail"},
+			startUser:   user,
+			startMode:   OWRITE,
+			wantUserNil: false,
+			wantMode:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fid := &Fid{
+				Fid:  1,
+				Clnt: clnt,
+				User: tt.startUser,
+				Mode: tt.startMode,
+			}
+			req := &Req{Tc: &Fcall{Type: tt.tcType}, Rc: tt.rc, fid: fid}
+			tag.respchan <- req
+			resp := waitReq(t, reqchan)
+			if resp != req {
+				t.Fatalf("unexpected req returned")
+			}
+			if tt.wantUserNil && fid.User != nil {
+				t.Fatalf("user not cleared")
+			}
+			if !tt.wantUserNil && fid.User == nil {
+				t.Fatalf("user cleared unexpectedly")
+			}
+			if tt.wantQid != (Qid{}) && fid.Qid != tt.wantQid {
+				t.Fatalf("qid = %+v, want %+v", fid.Qid, tt.wantQid)
+			}
+			if tt.wantIounit != 0 && fid.Iounit != tt.wantIounit {
+				t.Fatalf("iounit = %d, want %d", fid.Iounit, tt.wantIounit)
+			}
+			if fid.Mode != tt.wantMode {
+				t.Fatalf("mode = %d, want %d", fid.Mode, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestTagReqAllocFree(t *testing.T) {
+	_, tag, _ := newTestTag(t)
+	req := tag.reqAlloc()
+	if req.Tc == nil {
+		t.Fatalf("reqAlloc tc is nil")
+	}
+	tag.ReqFree(req)
+}
+
+func TestTagReqprocErrorMessage(t *testing.T) {
+	clnt, tag, reqchan := newTestTag(t)
+	user := stubUser{name: "user", id: 1}
+	fid := &Fid{Fid: 1, Clnt: clnt, User: user}
+	req := &Req{
+		Tc:  &Fcall{Type: Tattach},
+		Rc:  &Fcall{Type: Rerror, Error: "boom"},
+		fid: fid,
+	}
+	tag.respchan <- req
+	resp := waitReq(t, reqchan)
+	if resp.Rc.Type != Rerror {
+		t.Fatalf("rc type = %d", resp.Rc.Type)
+	}
+	if !strings.Contains(resp.Rc.Error, "boom") {
+		t.Fatalf("error = %q", resp.Rc.Error)
+	}
+}

--- a/srv_conn_test.go
+++ b/srv_conn_test.go
@@ -1,0 +1,36 @@
+package go9p
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestConnAddressesAndLogFcall(t *testing.T) {
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() {
+		_ = c1.Close()
+		_ = c2.Close()
+	})
+	srv := &Srv{Log: NewLogger(8)}
+	conn := &Conn{Srv: srv, conn: c1, Debuglevel: DbgLogPackets | DbgLogFcalls}
+
+	if conn.RemoteAddr() == nil {
+		t.Fatalf("RemoteAddr is nil")
+	}
+	if conn.LocalAddr() == nil {
+		t.Fatalf("LocalAddr is nil")
+	}
+
+	fc := &Fcall{Type: Tversion, Pkt: []byte("pkt")}
+	conn.logFcall(fc)
+}
+
+func TestStartNetListenerError(t *testing.T) {
+	srv := &Srv{}
+	if err := srv.StartNetListener("invalid", "addr"); err == nil {
+		t.Fatalf("expected error")
+	} else if !strings.Contains(err.Error(), "unknown network") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/srv_fcall_test.go
+++ b/srv_fcall_test.go
@@ -1,0 +1,575 @@
+package go9p
+
+import (
+	"strings"
+	"testing"
+)
+
+type testSrvOps struct {
+	authInitCalled    bool
+	authReadCalled    bool
+	authWriteCalled   bool
+	authDestroyCalled bool
+	createCalled      bool
+	clunkCalled       bool
+	removeCalled      bool
+	statCalled        bool
+	wstatCalled       bool
+}
+
+func (ops *testSrvOps) AuthInit(afid *SrvFid, aname string) (*Qid, error) {
+	ops.authInitCalled = true
+	return &Qid{Type: QTAUTH, Path: 1}, nil
+}
+
+func (ops *testSrvOps) AuthDestroy(afid *SrvFid) {
+	ops.authDestroyCalled = true
+}
+
+func (ops *testSrvOps) AuthCheck(fid *SrvFid, afid *SrvFid, aname string) error {
+	return nil
+}
+
+func (ops *testSrvOps) AuthRead(afid *SrvFid, offset uint64, data []byte) (int, error) {
+	ops.authReadCalled = true
+	return 0, nil
+}
+
+func (ops *testSrvOps) AuthWrite(afid *SrvFid, offset uint64, data []byte) (int, error) {
+	ops.authWriteCalled = true
+	return 0, nil
+}
+
+func (ops *testSrvOps) Attach(req *SrvReq) {
+	req.RespondRattach(&Qid{Type: QTDIR, Path: 1})
+}
+
+func (ops *testSrvOps) Walk(req *SrvReq) {
+	req.RespondRwalk(nil)
+}
+
+func (ops *testSrvOps) Open(req *SrvReq) {
+	req.RespondRopen(&Qid{Type: QTFILE, Path: 2}, 0)
+}
+
+func (ops *testSrvOps) Create(req *SrvReq) {
+	ops.createCalled = true
+	req.RespondRcreate(&Qid{Type: QTFILE, Path: 3}, 0)
+}
+
+func (ops *testSrvOps) Read(req *SrvReq) {
+	req.RespondRread([]byte("data"))
+}
+
+func (ops *testSrvOps) Write(req *SrvReq) {
+	req.RespondRwrite(req.Tc.Count)
+}
+
+func (ops *testSrvOps) Clunk(req *SrvReq) {
+	ops.clunkCalled = true
+	req.RespondRclunk()
+}
+
+func (ops *testSrvOps) Remove(req *SrvReq) {
+	ops.removeCalled = true
+	req.RespondRremove()
+}
+
+func (ops *testSrvOps) Stat(req *SrvReq) {
+	ops.statCalled = true
+	req.RespondRstat(&Dir{Name: "file"})
+}
+
+func (ops *testSrvOps) Wstat(req *SrvReq) {
+	ops.wstatCalled = true
+	req.RespondRwstat()
+}
+
+func newSrvReq(msgType uint8, ops *testSrvOps) *SrvReq {
+	srv := &Srv{Dotu: true, Msize: MSIZE, Upool: OsUsers, Maxpend: 1}
+	srv.Start(ops)
+	conn := &Conn{
+		Srv:     srv,
+		Msize:   MSIZE,
+		Dotu:    true,
+		fidpool: make(map[uint32]*SrvFid),
+		reqs:    make(map[uint16]*SrvReq),
+		reqout:  make(chan *SrvReq, 1),
+	}
+	req := &SrvReq{
+		Tc:   &Fcall{Type: msgType, Tag: 1},
+		Rc:   NewFcall(4096),
+		Conn: conn,
+	}
+	conn.reqs[req.Tc.Tag] = req
+	return req
+}
+
+func TestSrvAuth(t *testing.T) {
+	ops := &testSrvOps{}
+	req := newSrvReq(Tauth, ops)
+	req.Tc.Afid = 1
+	req.Tc.Unamenum = 2
+
+	req.Conn.Srv.auth(req)
+	if req.Rc.Type != Rauth {
+		t.Fatalf("auth type = %d", req.Rc.Type)
+	}
+	if !ops.authInitCalled {
+		t.Fatalf("AuthInit not called")
+	}
+	afid := req.Conn.fidpool[req.Tc.Afid]
+	if afid == nil {
+		t.Fatalf("afid missing")
+	}
+	if afid.Type&QTAUTH == 0 {
+		t.Fatalf("afid type = %d", afid.Type)
+	}
+	if afid.refcount != 1 {
+		t.Fatalf("afid refcount = %d", afid.refcount)
+	}
+}
+
+func TestSrvFlushNoRequest(t *testing.T) {
+	ops := &testSrvOps{}
+	req := newSrvReq(Tflush, ops)
+	req.Tc.Oldtag = 99
+
+	req.Conn.Srv.flush(req)
+	if req.Rc.Type != Rflush {
+		t.Fatalf("flush type = %d", req.Rc.Type)
+	}
+}
+
+func TestSrvCreate(t *testing.T) {
+	ops := &testSrvOps{}
+	req := newSrvReq(Tcreate, ops)
+	user := OsUsers.Uid2User(1)
+	req.Fid = &SrvFid{Fconn: req.Conn, User: user, Type: QTDIR}
+	req.Tc.Name = "file"
+	req.Tc.Perm = 0644
+	req.Tc.Mode = OREAD
+
+	req.Conn.Srv.create(req)
+	if req.Rc.Type != Rcreate {
+		t.Fatalf("create type = %d", req.Rc.Type)
+	}
+	if !ops.createCalled {
+		t.Fatalf("Create not called")
+	}
+}
+
+func TestSrvClunkRemoveStatWstat(t *testing.T) {
+	tests := []struct {
+		name     string
+		msgType  uint8
+		call     func(*Srv, *SrvReq)
+		wantType uint8
+		called   func(*testSrvOps) bool
+	}{
+		{
+			name:     "clunk",
+			msgType:  Tclunk,
+			call:     func(srv *Srv, req *SrvReq) { srv.clunk(req) },
+			wantType: Rclunk,
+			called:   func(ops *testSrvOps) bool { return ops.clunkCalled },
+		},
+		{
+			name:     "remove",
+			msgType:  Tremove,
+			call:     func(srv *Srv, req *SrvReq) { srv.remove(req) },
+			wantType: Rremove,
+			called:   func(ops *testSrvOps) bool { return ops.removeCalled },
+		},
+		{
+			name:     "stat",
+			msgType:  Tstat,
+			call:     func(srv *Srv, req *SrvReq) { srv.stat(req) },
+			wantType: Rstat,
+			called:   func(ops *testSrvOps) bool { return ops.statCalled },
+		},
+		{
+			name:     "wstat",
+			msgType:  Twstat,
+			call:     func(srv *Srv, req *SrvReq) { srv.wstat(req) },
+			wantType: Rwstat,
+			called:   func(ops *testSrvOps) bool { return ops.wstatCalled },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(tt.msgType, ops)
+			user := OsUsers.Uid2User(1)
+			req.Fid = &SrvFid{Fconn: req.Conn, User: user, Type: QTFILE}
+
+			req.Conn.Srv.ops = ops
+			tt.call(req.Conn.Srv, req)
+			if req.Rc.Type != tt.wantType {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !tt.called(ops) {
+				t.Fatalf("%s op not called", tt.name)
+			}
+		})
+	}
+}
+
+func TestSrvReadPaths(t *testing.T) {
+	user := OsUsers.Uid2User(1)
+	tests := []struct {
+		name       string
+		setup      func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps)
+		wantType   uint8
+		wantErr    string
+		wantAuth   bool
+		wantOffset uint64
+	}{
+		{
+			name: "auth-read",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTAUTH
+				req.Tc.Count = 4
+			},
+			wantType: Rread,
+			wantAuth: true,
+		},
+		{
+			name: "too-large",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTFILE
+				req.Tc.Count = req.Conn.Msize
+			},
+			wantType: Rerror,
+			wantErr:  "i/o count too large",
+		},
+		{
+			name: "dir-read",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTDIR
+				req.Tc.Count = 4
+				req.Tc.Offset = 0
+			},
+			wantType:   Rread,
+			wantOffset: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Tread, ops)
+			fid := &SrvFid{Fconn: req.Conn, User: user}
+			tt.setup(t, req, fid, ops)
+
+			req.Conn.Srv.read(req)
+			if req.Rc.Type != tt.wantType {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if tt.wantErr != "" && !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+			if tt.wantAuth && !ops.authReadCalled {
+				t.Fatalf("%s auth read not called", tt.name)
+			}
+			if tt.wantOffset != 0 && fid.Diroffset != tt.wantOffset {
+				t.Fatalf("%s offset = %d", tt.name, fid.Diroffset)
+			}
+		})
+	}
+}
+
+func TestSrvWritePaths(t *testing.T) {
+	user := OsUsers.Uid2User(1)
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps)
+		wantType uint8
+		wantErr  string
+		wantAuth bool
+	}{
+		{
+			name: "auth-write",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTAUTH
+				req.Tc.Data = []byte("data")
+				req.Tc.Count = uint32(len(req.Tc.Data))
+			},
+			wantType: Rwrite,
+			wantAuth: true,
+		},
+		{
+			name: "bad-use",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTFILE
+				fid.opened = false
+				req.Tc.Count = 1
+			},
+			wantType: Rerror,
+			wantErr:  "bad use of fid",
+		},
+		{
+			name: "too-large",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTFILE
+				fid.opened = true
+				fid.Omode = OWRITE
+				req.Tc.Count = req.Conn.Msize
+			},
+			wantType: Rerror,
+			wantErr:  "i/o count too large",
+		},
+		{
+			name: "normal",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid, ops *testSrvOps) {
+				req.Fid = fid
+				fid.Type = QTFILE
+				fid.opened = true
+				fid.Omode = OWRITE
+				req.Tc.Data = []byte("data")
+				req.Tc.Count = uint32(len(req.Tc.Data))
+			},
+			wantType: Rwrite,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Twrite, ops)
+			fid := &SrvFid{Fconn: req.Conn, User: user}
+			tt.setup(t, req, fid, ops)
+
+			req.Conn.Srv.write(req)
+			if req.Rc.Type != tt.wantType {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if tt.wantErr != "" && !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+			if tt.wantAuth && !ops.authWriteCalled {
+				t.Fatalf("%s auth write not called", tt.name)
+			}
+		})
+	}
+}
+
+func TestSrvAttachErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq)
+		wantErr string
+	}{
+		{
+			name: "no-fid",
+			setup: func(t *testing.T, req *SrvReq) {
+				req.Tc.Fid = NOFID
+			},
+			wantErr: "unknown fid",
+		},
+		{
+			name: "no-user",
+			setup: func(t *testing.T, req *SrvReq) {
+				req.Tc.Fid = 1
+				req.Conn.Dotu = false
+				req.Tc.Unamenum = NOUID
+			},
+			wantErr: "unknown user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Tattach, ops)
+			tt.setup(t, req)
+
+			req.Conn.Srv.attach(req)
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}
+
+func TestSrvWalkErrors(t *testing.T) {
+	user := OsUsers.Uid2User(1)
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq, fid *SrvFid)
+		wantErr string
+	}{
+		{
+			name: "not-dir",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTFILE
+				req.Tc.Wname = []string{"child"}
+				req.Tc.Fid = 1
+				req.Tc.Newfid = 1
+			},
+			wantErr: "not a directory",
+		},
+		{
+			name: "opened",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTDIR
+				fid.opened = true
+				req.Tc.Wname = nil
+				req.Tc.Fid = 1
+				req.Tc.Newfid = 1
+			},
+			wantErr: "bad use of fid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Twalk, ops)
+			fid := &SrvFid{Fconn: req.Conn, User: user}
+			req.Fid = fid
+			tt.setup(t, req, fid)
+
+			req.Conn.Srv.walk(req)
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}
+
+func TestSrvOpenErrors(t *testing.T) {
+	user := OsUsers.Uid2User(1)
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq, fid *SrvFid)
+		wantErr string
+	}{
+		{
+			name: "already-open",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.opened = true
+				req.Tc.Mode = OREAD
+			},
+			wantErr: "fid already opened",
+		},
+		{
+			name: "dir-write",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTDIR
+				req.Tc.Mode = OWRITE
+			},
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Topen, ops)
+			fid := &SrvFid{Fconn: req.Conn, User: user}
+			req.Fid = fid
+			tt.setup(t, req, fid)
+
+			req.Conn.Srv.open(req)
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}
+
+func TestSrvCreateErrors(t *testing.T) {
+	user := OsUsers.Uid2User(1)
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq, fid *SrvFid)
+		wantErr string
+	}{
+		{
+			name: "opened",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTDIR
+				fid.opened = true
+				req.Tc.Perm = 0644
+			},
+			wantErr: "fid already opened",
+		},
+		{
+			name: "not-dir",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTFILE
+				req.Tc.Perm = 0644
+			},
+			wantErr: "not a directory",
+		},
+		{
+			name: "dir-mode",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTDIR
+				req.Tc.Perm = DMDIR
+				req.Tc.Mode = OWRITE
+			},
+			wantErr: "permission denied",
+		},
+		{
+			name: "special-no-dotu",
+			setup: func(t *testing.T, req *SrvReq, fid *SrvFid) {
+				fid.Type = QTDIR
+				req.Conn.Dotu = false
+				req.Tc.Perm = DMSYMLINK
+				req.Tc.Mode = OREAD
+			},
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testSrvOps{}
+			req := newSrvReq(Tcreate, ops)
+			fid := &SrvFid{Fconn: req.Conn, User: user}
+			req.Fid = fid
+			tt.setup(t, req, fid)
+
+			req.Conn.Srv.create(req)
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}
+
+func TestSrvClunkAuth(t *testing.T) {
+	ops := &testSrvOps{}
+	req := newSrvReq(Tclunk, ops)
+	fid := &SrvFid{Fconn: req.Conn, User: OsUsers.Uid2User(1), Type: QTAUTH}
+	req.Fid = fid
+
+	req.Conn.Srv.clunk(req)
+	if req.Rc.Type != Rclunk {
+		t.Fatalf("clunk type = %d", req.Rc.Type)
+	}
+	if !ops.authDestroyCalled {
+		t.Fatalf("AuthDestroy not called")
+	}
+}

--- a/srv_file_test.go
+++ b/srv_file_test.go
@@ -1,6 +1,10 @@
 package go9p
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 type testGroup struct {
 	name string
@@ -24,6 +28,92 @@ func (u testUser) Id() int         { return u.id }
 func (u testUser) Groups() []Group { return u.groups }
 func (u testUser) IsMember(g Group) bool {
 	return false
+}
+
+type testFileOps struct {
+	openCalled    bool
+	createCalled  bool
+	readCalled    bool
+	writeCalled   bool
+	removeCalled  bool
+	statCalled    bool
+	wstatCalled   bool
+	clunkCalled   bool
+	destroyCalled bool
+
+	openErr   error
+	createErr error
+	readErr   error
+	writeErr  error
+	removeErr error
+	statErr   error
+	wstatErr  error
+	clunkErr  error
+
+	readData     []byte
+	writeData    []byte
+	bytesWritten int
+	createFile   *srvFile
+}
+
+func (ops *testFileOps) Open(fid *FFid, mode uint8) error {
+	ops.openCalled = true
+	return ops.openErr
+}
+
+func (ops *testFileOps) Create(fid *FFid, name string, perm uint32) (*srvFile, error) {
+	ops.createCalled = true
+	return ops.createFile, ops.createErr
+}
+
+func (ops *testFileOps) Read(fid *FFid, buf []byte, offset uint64) (int, error) {
+	ops.readCalled = true
+	if ops.readErr != nil {
+		return 0, ops.readErr
+	}
+	return copy(buf, ops.readData), nil
+}
+
+func (ops *testFileOps) Write(fid *FFid, data []byte, offset uint64) (int, error) {
+	ops.writeCalled = true
+	ops.writeData = append([]byte(nil), data...)
+	if ops.writeErr != nil {
+		return 0, ops.writeErr
+	}
+	if ops.bytesWritten != 0 {
+		return ops.bytesWritten, nil
+	}
+	return len(data), nil
+}
+
+func (ops *testFileOps) Remove(fid *FFid) error {
+	ops.removeCalled = true
+	return ops.removeErr
+}
+
+func (ops *testFileOps) Stat(fid *FFid) error {
+	ops.statCalled = true
+	return ops.statErr
+}
+
+func (ops *testFileOps) Wstat(fid *FFid, dir *Dir) error {
+	ops.wstatCalled = true
+	return ops.wstatErr
+}
+
+func (ops *testFileOps) Clunk(fid *FFid) error {
+	ops.clunkCalled = true
+	return ops.clunkErr
+}
+
+func (ops *testFileOps) FidDestroy(fid *FFid) {
+	ops.destroyCalled = true
+}
+
+func newFsrvReq(msgType uint8) *SrvReq {
+	req := newTestReq(msgType)
+	req.Rc = NewFcall(4096)
+	return req
 }
 
 func TestSrvFileAddAndFind(t *testing.T) {
@@ -182,5 +272,436 @@ func TestMode2Perm(t *testing.T) {
 				t.Fatalf("mode2Perm(%d) = %d, want %d", tt.mode, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFsrvAttachAndWalk(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	group := testGroup{name: "group", id: 2}
+	root := &srvFile{}
+	if err := root.Add(nil, "root", owner, group, DMDIR|0755, nil); err != nil {
+		t.Fatalf("Add root error = %v", err)
+	}
+	child := &srvFile{}
+	if err := child.Add(root, "child", owner, group, DMDIR|0755, nil); err != nil {
+		t.Fatalf("Add child error = %v", err)
+	}
+
+	srv := NewsrvFileSrv(root)
+	attachReq := newFsrvReq(Tattach)
+	fid := &SrvFid{Fconn: attachReq.Conn, User: owner}
+	attachReq.Fid = fid
+	srv.Attach(attachReq)
+	if attachReq.Rc.Type != Rattach {
+		t.Fatalf("Attach type = %d", attachReq.Rc.Type)
+	}
+	if fid.Aux == nil {
+		t.Fatalf("Attach fid aux nil")
+	}
+
+	tests := []struct {
+		name      string
+		wname     []string
+		wantErr   string
+		wantCount int
+	}{
+		{
+			name:      "walk-child",
+			wname:     []string{"child"},
+			wantCount: 1,
+		},
+		{
+			name:    "walk-missing",
+			wname:   []string{"missing"},
+			wantErr: "file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			walkReq := newFsrvReq(Twalk)
+			walkFid := &SrvFid{Fconn: walkReq.Conn, User: owner}
+			walkReq.Fid = walkFid
+			walkReq.Fid.Aux = &FFid{F: root, Fid: walkFid}
+			newfid := &SrvFid{Fconn: walkReq.Conn}
+			walkReq.Newfid = newfid
+			walkReq.Tc.Wname = tt.wname
+
+			srv.Walk(walkReq)
+			if tt.wantErr != "" {
+				if walkReq.Rc.Type != Rerror {
+					t.Fatalf("Walk type = %d", walkReq.Rc.Type)
+				}
+				if !strings.Contains(walkReq.Rc.Error, tt.wantErr) {
+					t.Fatalf("Walk error = %q", walkReq.Rc.Error)
+				}
+				return
+			}
+			if walkReq.Rc.Type != Rwalk {
+				t.Fatalf("Walk type = %d", walkReq.Rc.Type)
+			}
+			if len(walkReq.Rc.Wqid) != tt.wantCount {
+				t.Fatalf("Walk count = %d", len(walkReq.Rc.Wqid))
+			}
+			newAux := newfid.Aux.(*FFid)
+			if newAux.F != child {
+				t.Fatalf("Walk newfid = %+v", newAux.F)
+			}
+		})
+	}
+}
+
+func TestFsrvOpen(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+
+	tests := []struct {
+		name    string
+		user    User
+		wantErr string
+	}{
+		{
+			name: "allowed",
+			user: owner,
+		},
+		{
+			name:    "denied",
+			user:    nil,
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ops := &testFileOps{}
+			file := &srvFile{Dir: Dir{Mode: 0644, Uid: owner.name, Uidnum: uint32(owner.id)}}
+			file.ops = ops
+
+			req := newFsrvReq(Topen)
+			req.Fid = &SrvFid{Fconn: req.Conn, User: tt.user}
+			req.Fid.Aux = &FFid{F: file, Fid: req.Fid}
+			req.Tc.Mode = OREAD
+
+			(&Fsrv{}).Open(req)
+			if tt.wantErr != "" {
+				if req.Rc.Type != Rerror {
+					t.Fatalf("Open type = %d", req.Rc.Type)
+				}
+				if !strings.Contains(req.Rc.Error, tt.wantErr) {
+					t.Fatalf("Open error = %q", req.Rc.Error)
+				}
+				if ops.openCalled {
+					t.Fatalf("Open called unexpectedly")
+				}
+				return
+			}
+			if req.Rc.Type != Ropen {
+				t.Fatalf("Open type = %d", req.Rc.Type)
+			}
+			if !ops.openCalled {
+				t.Fatalf("Open not called")
+			}
+		})
+	}
+}
+
+func TestFsrvCreate(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	group := testGroup{name: "group", id: 2}
+
+	tests := []struct {
+		name    string
+		user    User
+		wantErr string
+	}{
+		{
+			name: "allowed",
+			user: owner,
+		},
+		{
+			name:    "denied",
+			user:    nil,
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := &srvFile{}
+			if err := dir.Add(nil, "root", owner, group, DMDIR|0755, nil); err != nil {
+				t.Fatalf("Add dir error = %v", err)
+			}
+			ops := &testFileOps{}
+			var child *srvFile
+			if tt.wantErr == "" {
+				child = &srvFile{}
+				if err := child.Add(dir, "new", owner, group, 0644, nil); err != nil {
+					t.Fatalf("Add child error = %v", err)
+				}
+				ops.createFile = child
+			}
+			dir.ops = ops
+
+			req := newFsrvReq(Tcreate)
+			fid := &SrvFid{Fconn: req.Conn, User: tt.user}
+			req.Fid = fid
+			req.Fid.Aux = &FFid{F: dir, Fid: fid}
+			req.Tc.Name = "new"
+			req.Tc.Perm = 0644
+			req.Tc.Mode = OREAD
+
+			(&Fsrv{}).Create(req)
+			if tt.wantErr != "" {
+				if req.Rc.Type != Rerror {
+					t.Fatalf("Create type = %d", req.Rc.Type)
+				}
+				if !strings.Contains(req.Rc.Error, tt.wantErr) {
+					t.Fatalf("Create error = %q", req.Rc.Error)
+				}
+				if ops.createCalled {
+					t.Fatalf("Create called unexpectedly")
+				}
+				return
+			}
+			if req.Rc.Type != Rcreate {
+				t.Fatalf("Create type = %d", req.Rc.Type)
+			}
+			if !ops.createCalled {
+				t.Fatalf("Create not called")
+			}
+			created := fid.Aux.(*FFid)
+			if created.F != child {
+				t.Fatalf("Create fid = %+v", created.F)
+			}
+		})
+	}
+}
+
+func TestFsrvReadWrite(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	ops := &testFileOps{readData: []byte("data")}
+	file := &srvFile{Dir: Dir{Mode: 0644, Uid: owner.name, Uidnum: uint32(owner.id)}}
+	file.ops = ops
+
+	readReq := newFsrvReq(Tread)
+	readReq.Fid = &SrvFid{Fconn: readReq.Conn, User: owner}
+	readReq.Fid.Aux = &FFid{F: file, Fid: readReq.Fid}
+	readReq.Tc.Count = 4
+	readReq.Tc.Offset = 0
+	(&Fsrv{}).Read(readReq)
+	if readReq.Rc.Type != Rread {
+		t.Fatalf("Read type = %d", readReq.Rc.Type)
+	}
+	if string(readReq.Rc.Data[:readReq.Rc.Count]) != "data" {
+		t.Fatalf("Read data = %q", string(readReq.Rc.Data[:readReq.Rc.Count]))
+	}
+	if !ops.readCalled {
+		t.Fatalf("Read not called")
+	}
+
+	writeReq := newFsrvReq(Twrite)
+	writeReq.Fid = &SrvFid{Fconn: writeReq.Conn, User: owner}
+	writeReq.Fid.Aux = &FFid{F: file, Fid: writeReq.Fid}
+	writeReq.Tc.Data = []byte("ping")
+	writeReq.Tc.Count = uint32(len(writeReq.Tc.Data))
+	writeReq.Tc.Offset = 0
+	(&Fsrv{}).Write(writeReq)
+	if writeReq.Rc.Type != Rwrite {
+		t.Fatalf("Write type = %d", writeReq.Rc.Type)
+	}
+	if string(ops.writeData) != "ping" {
+		t.Fatalf("Write data = %q", string(ops.writeData))
+	}
+	if !ops.writeCalled {
+		t.Fatalf("Write not called")
+	}
+}
+
+func TestFsrvRemove(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	group := testGroup{name: "group", id: 2}
+
+	tests := []struct {
+		name      string
+		withChild bool
+		wantErr   string
+	}{
+		{
+			name:      "not-empty",
+			withChild: true,
+			wantErr:   "directory not empty",
+		},
+		{
+			name: "ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &srvFile{}
+			if err := root.Add(nil, "root", owner, group, DMDIR|0755, nil); err != nil {
+				t.Fatalf("Add root error = %v", err)
+			}
+			target := &srvFile{}
+			ops := &testFileOps{}
+			if err := target.Add(root, "target", owner, group, 0644, ops); err != nil {
+				t.Fatalf("Add target error = %v", err)
+			}
+			if tt.withChild {
+				child := &srvFile{}
+				if err := child.Add(target, "child", owner, group, 0644, nil); err != nil {
+					t.Fatalf("Add child error = %v", err)
+				}
+			}
+
+			req := newFsrvReq(Tremove)
+			req.Fid = &SrvFid{Fconn: req.Conn, User: owner}
+			req.Fid.Aux = &FFid{F: target, Fid: req.Fid}
+			(&Fsrv{}).Remove(req)
+
+			if tt.wantErr != "" {
+				if req.Rc.Type != Rerror {
+					t.Fatalf("Remove type = %d", req.Rc.Type)
+				}
+				if !strings.Contains(req.Rc.Error, tt.wantErr) {
+					t.Fatalf("Remove error = %q", req.Rc.Error)
+				}
+				return
+			}
+			if req.Rc.Type != Rremove {
+				t.Fatalf("Remove type = %d", req.Rc.Type)
+			}
+			if root.Find("target") != nil {
+				t.Fatalf("Remove did not detach")
+			}
+			if !ops.removeCalled {
+				t.Fatalf("Remove op not called")
+			}
+		})
+	}
+}
+
+func TestFsrvStatAndWstat(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	file := &srvFile{Dir: Dir{Mode: 0644, Uid: owner.name, Uidnum: uint32(owner.id)}}
+
+	statTests := []struct {
+		name    string
+		statErr error
+		wantErr string
+	}{
+		{
+			name: "ok",
+		},
+		{
+			name:    "error",
+			statErr: errors.New("stat boom"),
+			wantErr: "stat boom",
+		},
+	}
+
+	for _, tt := range statTests {
+		t.Run("stat-"+tt.name, func(t *testing.T) {
+			ops := &testFileOps{statErr: tt.statErr}
+			file.ops = ops
+			req := newFsrvReq(Tstat)
+			req.Fid = &SrvFid{Fconn: req.Conn, User: owner}
+			req.Fid.Aux = &FFid{F: file, Fid: req.Fid}
+			(&Fsrv{}).Stat(req)
+			if tt.wantErr != "" {
+				if req.Rc.Type != Rerror {
+					t.Fatalf("Stat type = %d", req.Rc.Type)
+				}
+				if !strings.Contains(req.Rc.Error, tt.wantErr) {
+					t.Fatalf("Stat error = %q", req.Rc.Error)
+				}
+				return
+			}
+			if req.Rc.Type != Rstat {
+				t.Fatalf("Stat type = %d", req.Rc.Type)
+			}
+			if !ops.statCalled {
+				t.Fatalf("Stat op not called")
+			}
+		})
+	}
+
+	wstatTests := []struct {
+		name     string
+		withOps  bool
+		wstatErr error
+		wantErr  string
+	}{
+		{
+			name:    "ok",
+			withOps: true,
+		},
+		{
+			name:     "error",
+			withOps:  true,
+			wstatErr: errors.New("wstat boom"),
+			wantErr:  "wstat boom",
+		},
+		{
+			name:    "missing-ops",
+			withOps: false,
+			wantErr: "permission denied",
+		},
+	}
+
+	for _, tt := range wstatTests {
+		t.Run("wstat-"+tt.name, func(t *testing.T) {
+			var ops *testFileOps
+			if tt.withOps {
+				ops = &testFileOps{wstatErr: tt.wstatErr}
+				file.ops = ops
+			} else {
+				file.ops = nil
+			}
+			req := newFsrvReq(Twstat)
+			req.Fid = &SrvFid{Fconn: req.Conn, User: owner}
+			req.Fid.Aux = &FFid{F: file, Fid: req.Fid}
+			req.Tc.Dir = Dir{Name: "new"}
+			(&Fsrv{}).Wstat(req)
+			if tt.wantErr != "" {
+				if req.Rc.Type != Rerror {
+					t.Fatalf("Wstat type = %d", req.Rc.Type)
+				}
+				if !strings.Contains(req.Rc.Error, tt.wantErr) {
+					t.Fatalf("Wstat error = %q", req.Rc.Error)
+				}
+				return
+			}
+			if req.Rc.Type != Rwstat {
+				t.Fatalf("Wstat type = %d", req.Rc.Type)
+			}
+			if ops != nil && !ops.wstatCalled {
+				t.Fatalf("Wstat op not called")
+			}
+		})
+	}
+}
+
+func TestFsrvClunkAndFidDestroy(t *testing.T) {
+	owner := testUser{name: "owner", id: 1}
+	ops := &testFileOps{}
+	file := &srvFile{Dir: Dir{Mode: 0644, Uid: owner.name, Uidnum: uint32(owner.id)}}
+	file.ops = ops
+
+	clunkReq := newFsrvReq(Tclunk)
+	clunkReq.Fid = &SrvFid{Fconn: clunkReq.Conn, User: owner}
+	clunkReq.Fid.Aux = &FFid{F: file, Fid: clunkReq.Fid}
+	(&Fsrv{}).Clunk(clunkReq)
+	if clunkReq.Rc.Type != Rclunk {
+		t.Fatalf("Clunk type = %d", clunkReq.Rc.Type)
+	}
+	if !ops.clunkCalled {
+		t.Fatalf("Clunk op not called")
+	}
+
+	srvfid := &SrvFid{Fconn: clunkReq.Conn}
+	srvfid.Aux = &FFid{F: file, Fid: srvfid}
+	(&Fsrv{}).FidDestroy(srvfid)
+	if !ops.destroyCalled {
+		t.Fatalf("FidDestroy not called")
 	}
 }

--- a/srv_pipe_test.go
+++ b/srv_pipe_test.go
@@ -1,0 +1,321 @@
+//go:build unix && !tinygo
+
+package go9p
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newPipeReq(msgType uint8) *SrvReq {
+	req := newTestReq(msgType)
+	req.Rc = NewFcall(4096)
+	fid := &SrvFid{Fconn: req.Conn}
+	req.Fid = fid
+	return req
+}
+
+func TestPipefsConnLifecycle(t *testing.T) {
+	pipe := &Pipefs{}
+	conn := &Conn{Srv: &Srv{Debuglevel: 1}}
+	pipe.ConnOpened(conn)
+	pipe.ConnClosed(conn)
+}
+
+func TestPipefsFidDestroy(t *testing.T) {
+	pipe := &Pipefs{}
+	file, err := os.CreateTemp(t.TempDir(), "pipe")
+	if err != nil {
+		t.Fatalf("CreateTemp error = %v", err)
+	}
+	fid := &SrvFid{Aux: &pipeFid{file: file}}
+	pipe.FidDestroy(fid)
+	if _, err := file.WriteString("x"); err == nil {
+		t.Fatalf("expected write error on closed file")
+	}
+}
+
+func TestPipefsCreateStatRemove(t *testing.T) {
+	root := t.TempDir()
+	pipe := &Pipefs{Root: root}
+
+	createReq := newPipeReq(Tcreate)
+	createReq.Fid.Aux = &pipeFid{path: root}
+	createReq.Tc.Name = "newfile"
+	createReq.Tc.Perm = 0644
+	createReq.Tc.Mode = OWRITE
+	pipe.Create(createReq)
+	if createReq.Rc.Type != Rcreate {
+		t.Fatalf("Create type = %d", createReq.Rc.Type)
+	}
+
+	createdPath := filepath.Join(root, "newfile")
+	if _, err := os.Stat(createdPath); err != nil {
+		t.Fatalf("created file stat error = %v", err)
+	}
+
+	statReq := newPipeReq(Tstat)
+	statReq.Fid.Aux = &pipeFid{path: createdPath}
+	pipe.Stat(statReq)
+	if statReq.Rc.Type != Rstat {
+		t.Fatalf("Stat type = %d", statReq.Rc.Type)
+	}
+
+	removeReq := newPipeReq(Tremove)
+	removeReq.Fid.Aux = &pipeFid{path: createdPath}
+	pipe.Remove(removeReq)
+	if removeReq.Rc.Type != Rremove {
+		t.Fatalf("Remove type = %d", removeReq.Rc.Type)
+	}
+	if _, err := os.Stat(createdPath); !os.IsNotExist(err) {
+		t.Fatalf("Remove stat error = %v", err)
+	}
+}
+
+func TestPipefsWstatAndClunk(t *testing.T) {
+	root := t.TempDir()
+	pipe := &Pipefs{Root: root}
+
+	wstatReq := newPipeReq(Twstat)
+	wstatReq.Fid.Aux = &pipeFid{path: root}
+	pipe.Wstat(wstatReq)
+	if wstatReq.Rc.Type != Rerror {
+		t.Fatalf("Wstat type = %d", wstatReq.Rc.Type)
+	}
+	if !strings.Contains(wstatReq.Rc.Error, "permission denied") {
+		t.Fatalf("Wstat error = %q", wstatReq.Rc.Error)
+	}
+
+	clunkReq := newPipeReq(Tclunk)
+	clunkReq.Fid.Aux = &pipeFid{path: root}
+	pipe.Clunk(clunkReq)
+	if clunkReq.Rc.Type != Rclunk {
+		t.Fatalf("Clunk type = %d", clunkReq.Rc.Type)
+	}
+}
+
+func TestPipefsFlush(t *testing.T) {
+	pipe := &Pipefs{}
+	pipe.Flush(newPipeReq(Tflush))
+}
+
+func TestPipefsReadDirAndFile(t *testing.T) {
+	pipe := &Pipefs{}
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq) *pipeFid
+		wantErr string
+	}{
+		{
+			name: "dir",
+			setup: func(t *testing.T, req *SrvReq) *pipeFid {
+				root := t.TempDir()
+				filePath := filepath.Join(root, "file")
+				if err := os.WriteFile(filePath, []byte("data"), 0644); err != nil {
+					t.Fatalf("WriteFile error = %v", err)
+				}
+				file, err := os.Open(root)
+				if err != nil {
+					t.Fatalf("Open dir error = %v", err)
+				}
+				fid := &pipeFid{path: root, file: file}
+				req.Tc.Count = 2048
+				req.Tc.Offset = 0
+				return fid
+			},
+		},
+		{
+			name: "file",
+			setup: func(t *testing.T, req *SrvReq) *pipeFid {
+				root := t.TempDir()
+				filePath := filepath.Join(root, "file")
+				if err := os.WriteFile(filePath, []byte("data"), 0644); err != nil {
+					t.Fatalf("WriteFile error = %v", err)
+				}
+				fid := &pipeFid{path: filePath, data: []uint8("hello")}
+				req.Tc.Count = 5
+				req.Tc.Offset = 0
+				return fid
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newPipeReq(Tread)
+			fid := tt.setup(t, req)
+			req.Fid.Aux = fid
+
+			pipe.Read(req)
+			if req.Rc.Type != Rread {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			switch tt.name {
+			case "dir":
+				if req.Rc.Count == 0 {
+					t.Fatalf("dir read count = 0")
+				}
+			case "file":
+				if string(req.Rc.Data[:req.Rc.Count]) != "hello" {
+					t.Fatalf("file read = %q", string(req.Rc.Data[:req.Rc.Count]))
+				}
+				if len(fid.data) != 0 {
+					t.Fatalf("file data not drained")
+				}
+			}
+		})
+	}
+}
+
+func TestPipefsCreateVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, req *SrvReq, fid *pipeFid)
+		wantErr  string
+		wantType uint8
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, req *SrvReq, fid *pipeFid) {
+				root := t.TempDir()
+				fid.path = root
+				target := filepath.Join(root, "target")
+				if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+					t.Fatalf("WriteFile error = %v", err)
+				}
+				req.Tc.Name = "link"
+				req.Tc.Perm = DMSYMLINK
+				req.Tc.Ext = target
+				req.Tc.Mode = OREAD
+			},
+			wantType: Rcreate,
+		},
+		{
+			name: "hardlink",
+			setup: func(t *testing.T, req *SrvReq, fid *pipeFid) {
+				root := t.TempDir()
+				fid.path = root
+				target := filepath.Join(root, "target")
+				if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+					t.Fatalf("WriteFile error = %v", err)
+				}
+				linkFid := &SrvFid{Fconn: req.Conn, Aux: &pipeFid{path: target}}
+				req.Conn.fidpool[99] = linkFid
+				req.Tc.Name = "hardlink"
+				req.Tc.Perm = DMLINK
+				req.Tc.Ext = "99"
+				req.Tc.Mode = OREAD
+			},
+			wantType: Rcreate,
+		},
+		{
+			name: "device-error",
+			setup: func(t *testing.T, req *SrvReq, fid *pipeFid) {
+				root := t.TempDir()
+				fid.path = root
+				req.Tc.Name = "device"
+				req.Tc.Perm = DMDEVICE
+			},
+			wantType: Rerror,
+			wantErr:  "not implemented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newPipeReq(Tcreate)
+			fid := &pipeFid{}
+			req.Fid.Aux = fid
+			tt.setup(t, req, fid)
+
+			(&Pipefs{}).Create(req)
+			if req.Rc.Type != tt.wantType {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if tt.wantErr != "" && !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}
+
+func TestPipefsErrorPaths(t *testing.T) {
+	pipe := &Pipefs{}
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) *SrvReq
+		wantErr string
+	}{
+		{
+			name: "attach-afid",
+			setup: func(t *testing.T) *SrvReq {
+				req := newPipeReq(Tattach)
+				req.Afid = &SrvFid{Fconn: req.Conn}
+				pipe.Attach(req)
+				return req
+			},
+			wantErr: "no authentication required",
+		},
+		{
+			name: "open-missing",
+			setup: func(t *testing.T) *SrvReq {
+				req := newPipeReq(Topen)
+				missing := filepath.Join(t.TempDir(), "missing")
+				req.Fid.Aux = &pipeFid{path: missing}
+				pipe.Open(req)
+				return req
+			},
+			wantErr: "no such file",
+		},
+		{
+			name: "remove-missing",
+			setup: func(t *testing.T) *SrvReq {
+				req := newPipeReq(Tremove)
+				missing := filepath.Join(t.TempDir(), "missing")
+				req.Fid.Aux = &pipeFid{path: missing}
+				pipe.Remove(req)
+				return req
+			},
+			wantErr: "no such file",
+		},
+		{
+			name: "stat-missing",
+			setup: func(t *testing.T) *SrvReq {
+				req := newPipeReq(Tstat)
+				missing := filepath.Join(t.TempDir(), "missing")
+				req.Fid.Aux = &pipeFid{path: missing}
+				pipe.Stat(req)
+				return req
+			},
+			wantErr: "no such file",
+		},
+		{
+			name: "walk-missing",
+			setup: func(t *testing.T) *SrvReq {
+				req := newPipeReq(Twalk)
+				missing := filepath.Join(t.TempDir(), "missing")
+				req.Fid.Aux = &pipeFid{path: missing}
+				req.Newfid = &SrvFid{Fconn: req.Conn}
+				req.Tc.Wname = []string{"child"}
+				pipe.Walk(req)
+				return req
+			},
+			wantErr: "no such file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.setup(t)
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}

--- a/srv_srv_test.go
+++ b/srv_srv_test.go
@@ -1,0 +1,67 @@
+package go9p
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSrvAndConnString(t *testing.T) {
+	srv := &Srv{Id: "srv"}
+	if srv.String() != "srv" {
+		t.Fatalf("Srv.String() = %q", srv.String())
+	}
+	conn := &Conn{Srv: srv, Id: "conn"}
+	if conn.String() != "srv/conn" {
+		t.Fatalf("Conn.String() = %q", conn.String())
+	}
+}
+
+func TestSrvReqFlush(t *testing.T) {
+	req := newTestReq(Tflush)
+	req.Flush()
+	if req.status&reqFlush == 0 {
+		t.Fatalf("reqFlush not set")
+	}
+	if req.status&reqResponded == 0 {
+		t.Fatalf("reqResponded not set")
+	}
+}
+
+func TestSrvReqProcessErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, req *SrvReq)
+		wantErr string
+	}{
+		{
+			name: "unknown-type",
+			setup: func(t *testing.T, req *SrvReq) {
+				req.Tc.Type = 0xff
+				req.Tc.Fid = NOFID
+			},
+			wantErr: "unknown message type",
+		},
+		{
+			name: "unknown-fid",
+			setup: func(t *testing.T, req *SrvReq) {
+				req.Tc.Type = Topen
+				req.Tc.Fid = 123
+			},
+			wantErr: "unknown fid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newTestReq(Tversion)
+			tt.setup(t, req)
+			req.Process()
+			if req.Rc.Type != Rerror {
+				t.Fatalf("%s type = %d", tt.name, req.Rc.Type)
+			}
+			if !strings.Contains(req.Rc.Error, tt.wantErr) {
+				t.Fatalf("%s error = %q", tt.name, req.Rc.Error)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for client and server packages
- 1912 lines of test code across 8 files (6 new, 2 enhanced)

## Added

- `clnt_clnt_test.go`: tests for `FidFile` and client Fcall logging
- `clnt_tag_test.go`: tests for tag methods, request processing, allocation, and error handling
- `srv_conn_test.go`: tests for server connection address handling, Fcall logging, and network listener error cases
- `srv_fcall_test.go`: tests for all 9P server Fcall handlers (auth, flush, create, clunk, remove, stat, walk, open, read, write)
- `srv_pipe_test.go`: tests for Pipefs server implementation
- `srv_srv_test.go`: tests for Srv and Conn string representations, request flush, and error handling

## Changed

- `srv_file_test.go`: expanded with tests for Fsrv attach, walk, open, create, read, write, remove, stat, wstat, clunk, fid destroy
- `ufs_test.go`: enhanced with tests for Ufs create, open, clunk, flush operations

## Test Plan

- [x] All tests pass locally (`go test ./...`)
- [x] Pre-commit hooks pass